### PR TITLE
Use local copy of README.md in setup.py.

### DIFF
--- a/py/setup.py
+++ b/py/setup.py
@@ -15,7 +15,7 @@
 from os.path import dirname, join, abspath
 from setuptools import setup
 
-with open(join(abspath(dirname(__file__)), '..', 'README.md'), 'r') as fh:
+with open(join(abspath(dirname(__file__)), 'README.md'), 'r') as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
setup.py expects a copy of README.md to be available. Update it to use the copy that's placed in the py/ folder by the build pipeline.